### PR TITLE
Add MenuRouter for centralized menu dispatch

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -2,3 +2,4 @@
 [2507282231][d81bbc][FTR] Implement main window with menu bar
 [2507282257][57b6fb][REF] Centralize menu actions
 [2507282304][44ce88][FTR][REF] Add MenuActions constants and refactor handler
+[2507282329][a439c0][FTR][REF] Add MenuRouter to dispatch menu events

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:window_manager/window_manager.dart';
-import 'menu_action_handler.dart';
+import 'menu_constants.dart';
+import 'menu_router.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -58,11 +59,11 @@ class MenuBarWidget extends StatelessWidget {
             SubmenuButton(
               menuChildren: [
                 MenuItemButton(
-                  onPressed: MenuActionHandler.onOpenJson,
+                  onPressed: () => MenuRouter.handle(MenuActions.openJson),
                   child: const Text('Json'),
                 ),
                 MenuItemButton(
-                  onPressed: MenuActionHandler.onOpenVault,
+                  onPressed: () => MenuRouter.handle(MenuActions.openVault),
                   child: const Text('Vault'),
                 ),
               ],
@@ -71,18 +72,20 @@ class MenuBarWidget extends StatelessWidget {
             SubmenuButton(
               menuChildren: [
                 MenuItemButton(
-                  onPressed: MenuActionHandler.onExportPlaceholder1,
+                  onPressed: () =>
+                      MenuRouter.handle(MenuActions.exportPlaceholder1),
                   child: const Text('Placeholder1'),
                 ),
                 MenuItemButton(
-                  onPressed: MenuActionHandler.onExportPlaceholder2,
+                  onPressed: () =>
+                      MenuRouter.handle(MenuActions.exportPlaceholder2),
                   child: const Text('Placeholder2'),
                 ),
               ],
               child: const Text('Export'),
             ),
             MenuItemButton(
-              onPressed: MenuActionHandler.onExit,
+              onPressed: () => MenuRouter.handle(MenuActions.exitApp),
               child: const Text('Exit'),
             ),
           ],
@@ -91,7 +94,7 @@ class MenuBarWidget extends StatelessWidget {
         SubmenuButton(
           menuChildren: [
             MenuItemButton(
-              onPressed: MenuActionHandler.onViewContext,
+              onPressed: () => MenuRouter.handle(MenuActions.viewContext),
               child: const Text('Context'),
             ),
           ],
@@ -102,11 +105,13 @@ class MenuBarWidget extends StatelessWidget {
             SubmenuButton(
               menuChildren: [
                 MenuItemButton(
-                  onPressed: MenuActionHandler.onSelectModelGPT,
+                  onPressed: () =>
+                      MenuRouter.handle(MenuActions.selectModelGpt),
                   child: const Text('GPT 3.5-turbo'),
                 ),
                 MenuItemButton(
-                  onPressed: MenuActionHandler.onSelectModelGemini,
+                  onPressed: () =>
+                      MenuRouter.handle(MenuActions.selectModelGemini),
                   child: const Text('Gemini 1.5'),
                 ),
               ],

--- a/lib/menu_router.dart
+++ b/lib/menu_router.dart
@@ -1,0 +1,35 @@
+import 'menu_constants.dart';
+import 'menu_action_handler.dart';
+
+/// Routes menu action strings to their corresponding handlers in [MenuActionHandler].
+class MenuRouter {
+  /// Dispatches a menu [action] to the proper handler.
+  static void handle(String action) {
+    switch (action) {
+      case MenuActions.openJson:
+        MenuActionHandler.onOpenJson();
+        break;
+      case MenuActions.openVault:
+        MenuActionHandler.onOpenVault();
+        break;
+      case MenuActions.exportPlaceholder1:
+        MenuActionHandler.onExportPlaceholder1();
+        break;
+      case MenuActions.exportPlaceholder2:
+        MenuActionHandler.onExportPlaceholder2();
+        break;
+      case MenuActions.exitApp:
+        MenuActionHandler.onExit();
+        break;
+      case MenuActions.viewContext:
+        MenuActionHandler.onViewContext();
+        break;
+      case MenuActions.selectModelGpt:
+        MenuActionHandler.onSelectModelGPT();
+        break;
+      case MenuActions.selectModelGemini:
+        MenuActionHandler.onSelectModelGemini();
+        break;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `MenuRouter` class to route menu events to handlers
- update `MenuBarWidget` to use `MenuRouter.handle`
- log the new feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68880767cc1883219f64cb3b0addb4d6