### PR TITLE
Add search/filter bar placeholder

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -3,3 +3,4 @@
 [2507282257][57b6fb][REF] Centralize menu actions
 [2507282304][44ce88][FTR][REF] Add MenuActions constants and refactor handler
 [2507282329][a439c0][FTR][REF] Add MenuRouter to dispatch menu events
+[2507282353][a43c05][FTR] Add search and filter bar placeholder

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,8 +32,24 @@ class CodexVaultApp extends StatelessWidget {
   }
 }
 
-class ScaffoldWithMenu extends StatelessWidget {
+class ScaffoldWithMenu extends StatefulWidget {
   const ScaffoldWithMenu({super.key});
+
+  @override
+  State<ScaffoldWithMenu> createState() => _ScaffoldWithMenuState();
+
+}
+
+class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
+  final TextEditingController _searchController = TextEditingController();
+  final TextEditingController _filterController = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _filterController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -42,7 +58,46 @@ class ScaffoldWithMenu extends StatelessWidget {
         preferredSize: const Size.fromHeight(kToolbarHeight),
         child: const MenuBarWidget(),
       ),
-      body: const Center(child: Text('CodexVault UI Placeholder')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: SizedBox(
+              height: 48,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _searchController,
+                      onChanged: (value) => print('Search: $value'),
+                      decoration: const InputDecoration(
+                        labelText: 'Search...',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: TextField(
+                      controller: _filterController,
+                      onChanged: (value) => print('Filter: $value'),
+                      decoration: const InputDecoration(
+                        labelText: 'Filter...',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const Expanded(
+            child: Center(
+              child: Text('CodexVault UI Placeholder'),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- convert `ScaffoldWithMenu` to a StatefulWidget
- add search and filter fields with controllers
- log field changes to console
- update CODEX log

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68880b9a2fbc8321b204fdbe6b78439f