### PR TITLE
Add filter dropdown for filter field

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -5,3 +5,4 @@
 [2507282329][a439c0][FTR][REF] Add MenuRouter to dispatch menu events
 [2507282353][a43c05][FTR] Add search and filter bar placeholder
 [2507282354][a0eab6][REF] Improve search and filter bar styling
+[2507290053][5dc9b30][FTR] Add filter dropdown next to filter field

--- a/lib/filter_state.dart
+++ b/lib/filter_state.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+/// Manages the currently selected filter type for the filter dropdown.
+class FilterState {
+  /// Selected filter type displayed in the dropdown. Defaults to 'All'.
+  static final ValueNotifier<String> selectedFilter =
+      ValueNotifier<String>('All');
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:window_manager/window_manager.dart';
 import 'menu_constants.dart';
 import 'menu_router.dart';
 import 'search_filter_controller.dart';
+import 'filter_state.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -105,6 +106,40 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                             ),
                           ),
                         ),
+                      ),
+                      const SizedBox(width: 12),
+                      ValueListenableBuilder<String>(
+                        valueListenable: FilterState.selectedFilter,
+                        builder: (context, value, child) {
+                          return DropdownButton<String>(
+                            hint: const Text('Select Filter Type'),
+                            value: value,
+                            onChanged: (newValue) {
+                              if (newValue != null) {
+                                FilterState.selectedFilter.value = newValue;
+                                debugPrint('Filter type selected: $newValue');
+                              }
+                            },
+                            items: const [
+                              DropdownMenuItem(
+                                value: 'All',
+                                child: Text('All'),
+                              ),
+                              DropdownMenuItem(
+                                value: 'Vaults',
+                                child: Text('Vaults'),
+                              ),
+                              DropdownMenuItem(
+                                value: 'Conversations',
+                                child: Text('Conversations'),
+                              ),
+                              DropdownMenuItem(
+                                value: 'Exchanges',
+                                child: Text('Exchanges'),
+                              ),
+                            ],
+                          );
+                        },
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- provide `FilterState` with `ValueNotifier<String>` to track selected filter
- import `filter_state.dart` in `main.dart`
- add dropdown next to filter TextField

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68881afb16688321bded5cff560007b9