### PR TITLE
Implement split layout in main view

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -6,3 +6,4 @@
 [2507282353][a43c05][FTR] Add search and filter bar placeholder
 [2507282354][a0eab6][REF] Improve search and filter bar styling
 [2507290053][5dc9b30][FTR] Add filter dropdown next to filter field
+[2507290108][6a7bde][FTR] Add split layout with two placeholder panels

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -147,9 +147,25 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
               ),
             ),
           ),
-          const Expanded(
-            child: Center(
-              child: Text('CodexVault UI Placeholder'),
+          Expanded(
+            child: Row(
+              children: [
+                Container(
+                  width: 300,
+                  margin: const EdgeInsets.all(8),
+                  padding: const EdgeInsets.all(8),
+                  color: Theme.of(context).colorScheme.surfaceVariant,
+                  child: const Center(child: Text('Navigation Panel')),
+                ),
+                Expanded(
+                  child: Container(
+                    margin: const EdgeInsets.all(8),
+                    padding: const EdgeInsets.all(8),
+                    color: Theme.of(context).colorScheme.surfaceVariant,
+                    child: const Center(child: Text('Detail Panel')),
+                  ),
+                ),
+              ],
             ),
           ),
         ],


### PR DESCRIPTION
## Summary
- create navigation and detail panel placeholders below search/filter bar
- record log entry for split layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68881eb726bc832198a04f0a450cc328