### PR TITLE
Implement resizable navigation panel

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -7,3 +7,4 @@
 [2507282354][a0eab6][REF] Improve search and filter bar styling
 [2507290053][5dc9b30][FTR] Add filter dropdown next to filter field
 [2507290108][6a7bde][FTR] Add split layout with two placeholder panels
+[2507290125][8eeca17][FTR] Make navigation panel resizable

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'menu_constants.dart';
 import 'menu_router.dart';
 import 'search_filter_controller.dart';
 import 'filter_state.dart';
+import 'ui/widgets/resizable_widget.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -150,12 +151,15 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
           Expanded(
             child: Row(
               children: [
-                Container(
-                  width: 300,
-                  margin: const EdgeInsets.all(8),
-                  padding: const EdgeInsets.all(8),
-                  color: Theme.of(context).colorScheme.surfaceVariant,
-                  child: const Center(child: Text('Navigation Panel')),
+                ResizableWidget(
+                  minWidth: 200,
+                  maxWidth: 500,
+                  child: Container(
+                    margin: const EdgeInsets.all(8),
+                    padding: const EdgeInsets.all(8),
+                    color: Theme.of(context).colorScheme.surfaceVariant,
+                    child: const Center(child: Text('Navigation Panel')),
+                  ),
                 ),
                 Expanded(
                   child: Container(

--- a/lib/ui/widgets/resizable_widget.dart
+++ b/lib/ui/widgets/resizable_widget.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class ResizableWidget extends StatefulWidget {
+  const ResizableWidget({
+    super.key,
+    required this.child,
+    this.initialWidth = 300,
+    this.minWidth = 200,
+    this.maxWidth = 500,
+  });
+
+  final Widget child;
+  final double initialWidth;
+  final double minWidth;
+  final double maxWidth;
+
+  @override
+  State<ResizableWidget> createState() => _ResizableWidgetState();
+}
+
+class _ResizableWidgetState extends State<ResizableWidget> {
+  late double _width;
+
+  @override
+  void initState() {
+    super.initState();
+    _width = widget.initialWidth;
+  }
+
+  void _updateWidth(double delta) {
+    setState(() {
+      _width += delta;
+      if (_width < widget.minWidth) _width = widget.minWidth;
+      if (_width > widget.maxWidth) _width = widget.maxWidth;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(width: _width, child: widget.child),
+        MouseRegion(
+          cursor: SystemMouseCursors.resizeLeftRight,
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onHorizontalDragUpdate: (details) => _updateWidth(details.delta.dx),
+            child: Container(
+              width: 6,
+              color: Theme.of(context).dividerColor,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a `ResizableWidget` for draggable horizontal panels
- swap fixed-width navigation panel for `ResizableWidget`
- log new feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6888226fd0e083218c7554284bedce29