### PR TITLE
Add placeholder selection status indicator

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -11,3 +11,4 @@
 [2507290202][ec9b13][FTR] Populate navigation and detail panels with mock content
 [2507290209][6fa01ca][FTR] Add status bar pinned to bottom
 [2507290530][e8a240][FTR] Display selected model in status bar
+[2507290745][eb1e2b6][FTR] Add selection state and status bar updater

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'search_filter_controller.dart';
 import 'filter_state.dart';
 import 'llm_state.dart';
 import 'conversation_state.dart';
+import 'selection_state.dart';
 import 'ui/widgets/resizable_widget.dart';
 
 void main() async {
@@ -164,39 +165,49 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                     padding: const EdgeInsets.all(8),
                     color: Theme.of(context).colorScheme.surfaceVariant,
                     child: ListView(
-                      children: const [
+                      children: [
                         ListTile(
                           dense: true,
-                          title: Text('Vault A'),
-                          trailing: Icon(Icons.keyboard_arrow_down),
+                          title: const Text('Vault A'),
+                          trailing: const Icon(Icons.keyboard_arrow_down),
+                          onTap: () =>
+                              selectedItemLabel.value = 'Selected: Vault A',
                         ),
                         Padding(
-                          padding: EdgeInsets.only(left: 16),
+                          padding: const EdgeInsets.only(left: 16),
                           child: ListTile(
                             dense: true,
-                            title: Text('Conversation A1'),
-                            trailing: Icon(Icons.chevron_right),
+                            title: const Text('Conversation A1'),
+                            trailing: const Icon(Icons.chevron_right),
+                            onTap: () => selectedItemLabel.value =
+                                'Selected: Conversation A1',
                           ),
                         ),
                         Padding(
-                          padding: EdgeInsets.only(left: 16),
+                          padding: const EdgeInsets.only(left: 16),
                           child: ListTile(
                             dense: true,
-                            title: Text('Conversation A2'),
-                            trailing: Icon(Icons.chevron_right),
+                            title: const Text('Conversation A2'),
+                            trailing: const Icon(Icons.chevron_right),
+                            onTap: () => selectedItemLabel.value =
+                                'Selected: Conversation A2',
                           ),
                         ),
                         ListTile(
                           dense: true,
-                          title: Text('Vault B'),
-                          trailing: Icon(Icons.keyboard_arrow_down),
+                          title: const Text('Vault B'),
+                          trailing: const Icon(Icons.keyboard_arrow_down),
+                          onTap: () =>
+                              selectedItemLabel.value = 'Selected: Vault B',
                         ),
                         Padding(
-                          padding: EdgeInsets.only(left: 16),
+                          padding: const EdgeInsets.only(left: 16),
                           child: ListTile(
                             dense: true,
-                            title: Text('Conversation B1'),
-                            trailing: Icon(Icons.chevron_right),
+                            title: const Text('Conversation B1'),
+                            trailing: const Icon(Icons.chevron_right),
+                            onTap: () => selectedItemLabel.value =
+                                'Selected: Conversation B1',
                           ),
                         ),
                       ],
@@ -312,6 +323,18 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                     builder: (context, count, child) {
                       return Text(
                         'Conversations: $count',
+                        style: Theme.of(context).textTheme.labelSmall,
+                      );
+                    },
+                  ),
+                  const SizedBox(width: 12),
+                  const VerticalDivider(width: 1),
+                  const SizedBox(width: 12),
+                  ValueListenableBuilder<String>(
+                    valueListenable: selectedItemLabel,
+                    builder: (context, label, child) {
+                      return Text(
+                        label,
                         style: Theme.of(context).textTheme.labelSmall,
                       );
                     },

--- a/lib/selection_state.dart
+++ b/lib/selection_state.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+/// Holds the label describing the currently selected navigation item.
+final ValueNotifier<String> selectedItemLabel =
+    ValueNotifier<String>('No item selected');


### PR DESCRIPTION
## Summary
- create `selection_state.dart` to hold current selection label
- update navigation list tiles to update selection state on tap
- display selected item label in the status bar
- log the new feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68887bc202948321ab12183e03365a39