### PR TITLE
Sync navigation panel with view mode

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -15,3 +15,4 @@
 [2507290823][fecc47][REF] Centralize state with GlobalState singletons
 [2507290831][95e200][FTR] Implement view mode selection menu and state updates
 [2507292220][d35ce9][FTR] Show selected item details in right panel
+[2507292313][3834de][FTR] Sync navigation panel with current view mode

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -162,53 +162,108 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                     margin: const EdgeInsets.all(8),
                     padding: const EdgeInsets.all(8),
                     color: Theme.of(context).colorScheme.surfaceVariant,
-                    child: ListView(
-                      children: [
-                        ListTile(
-                          dense: true,
-                          title: const Text('Vault A'),
-                          trailing: const Icon(Icons.keyboard_arrow_down),
-                          onTap: () =>
-                              GlobalState.selectedItemLabel.value = 'Selected: Vault A',
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(left: 16),
-                          child: ListTile(
-                            dense: true,
-                            title: const Text('Conversation A1'),
-                            trailing: const Icon(Icons.chevron_right),
-                            onTap: () => GlobalState.selectedItemLabel.value =
-                                'Selected: Conversation A1',
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(left: 16),
-                          child: ListTile(
-                            dense: true,
-                            title: const Text('Conversation A2'),
-                            trailing: const Icon(Icons.chevron_right),
-                            onTap: () => GlobalState.selectedItemLabel.value =
-                                'Selected: Conversation A2',
-                          ),
-                        ),
-                        ListTile(
-                          dense: true,
-                          title: const Text('Vault B'),
-                          trailing: const Icon(Icons.keyboard_arrow_down),
-                          onTap: () =>
-                              GlobalState.selectedItemLabel.value = 'Selected: Vault B',
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(left: 16),
-                          child: ListTile(
-                            dense: true,
-                            title: const Text('Conversation B1'),
-                            trailing: const Icon(Icons.chevron_right),
-                            onTap: () => GlobalState.selectedItemLabel.value =
-                                'Selected: Conversation B1',
-                          ),
-                        ),
-                      ],
+                    child: ValueListenableBuilder<ViewMode>(
+                      valueListenable: GlobalState.currentViewMode,
+                      builder: (context, mode, child) {
+                        if (mode == ViewMode.context) {
+                          return ListView(
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    vertical: 4, horizontal: 8),
+                                child: Text(
+                                  'Context Blocks',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .labelLarge,
+                                ),
+                              ),
+                              ListTile(
+                                dense: true,
+                                leading: const Icon(Icons.description_outlined),
+                                title: const Text('Context Block A'),
+                                onTap: () => GlobalState.selectedItemLabel.value =
+                                    'Selected: Context Block A',
+                              ),
+                              ListTile(
+                                dense: true,
+                                leading: const Icon(Icons.description_outlined),
+                                title: const Text('Context Block B'),
+                                onTap: () => GlobalState.selectedItemLabel.value =
+                                    'Selected: Context Block B',
+                              ),
+                            ],
+                          );
+                        }
+                        return ListView(
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                  vertical: 4, horizontal: 8),
+                              child: Text(
+                                'Vaults',
+                                style:
+                                    Theme.of(context).textTheme.labelLarge,
+                              ),
+                            ),
+                            ListTile(
+                              dense: true,
+                              leading: const Icon(Icons.folder),
+                              title: const Text('Vault A'),
+                              trailing: const Icon(Icons.keyboard_arrow_down),
+                              onTap: () => GlobalState.selectedItemLabel.value =
+                                  'Selected: Vault A',
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 16),
+                              child: ListTile(
+                                dense: true,
+                                leading: const Icon(Icons.chat),
+                                title: const Text('Conversation A1'),
+                                trailing: const Icon(Icons.chevron_right),
+                                onTap: () => GlobalState
+                                    .selectedItemLabel
+                                    .value =
+                                    'Selected: Conversation A1',
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 16),
+                              child: ListTile(
+                                dense: true,
+                                leading: const Icon(Icons.chat),
+                                title: const Text('Conversation A2'),
+                                trailing: const Icon(Icons.chevron_right),
+                                onTap: () => GlobalState
+                                    .selectedItemLabel
+                                    .value =
+                                    'Selected: Conversation A2',
+                              ),
+                            ),
+                            ListTile(
+                              dense: true,
+                              leading: const Icon(Icons.folder),
+                              title: const Text('Vault B'),
+                              trailing: const Icon(Icons.keyboard_arrow_down),
+                              onTap: () => GlobalState.selectedItemLabel.value =
+                                  'Selected: Vault B',
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 16),
+                              child: ListTile(
+                                dense: true,
+                                leading: const Icon(Icons.chat),
+                                title: const Text('Conversation B1'),
+                                trailing: const Icon(Icons.chevron_right),
+                                onTap: () => GlobalState
+                                    .selectedItemLabel
+                                    .value =
+                                    'Selected: Conversation B1',
+                              ),
+                            ),
+                          ],
+                        );
+                      },
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- update nav panel contents according to `GlobalState.currentViewMode`
- include context block items for `ViewMode.context`
- update CODEX log

## Testing
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6889553f86188321a3affe04124f4f4e