### PR TITLE
Implement mock data loader with dynamic tree view

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -16,3 +16,4 @@
 [2507290831][95e200][FTR] Implement view mode selection menu and state updates
 [2507292220][d35ce9][FTR] Show selected item details in right panel
 [2507292313][3834de][FTR] Sync navigation panel with current view mode
+[2507292321][75aee2][FTR] Load mock data and render navigation dynamically

--- a/lib/data/mock_data_loader.dart
+++ b/lib/data/mock_data_loader.dart
@@ -1,0 +1,33 @@
+
+/// Represents a conversation item with a title and timestamp.
+class Conversation {
+  final String title;
+  final DateTime timestamp;
+
+  Conversation({required this.title, required this.timestamp});
+}
+
+/// Represents a vault containing a list of conversations.
+class Vault {
+  final String name;
+  final List<Conversation> conversations;
+
+  Vault({required this.name, required this.conversations});
+}
+
+/// Provides mock vault and conversation data for development.
+class MockDataLoader {
+  /// Returns a list of [Vault] objects populated with mock conversations.
+  static List<Vault> load() {
+    final now = DateTime.now();
+    return [
+      Vault(name: 'Vault A', conversations: [
+        Conversation(title: 'Conversation A1', timestamp: now.subtract(const Duration(days: 1))),
+        Conversation(title: 'Conversation A2', timestamp: now.subtract(const Duration(days: 2))),
+      ]),
+      Vault(name: 'Vault B', conversations: [
+        Conversation(title: 'Conversation B1', timestamp: now.subtract(const Duration(days: 3))),
+      ]),
+    ];
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'menu_router.dart';
 import 'search_filter_controller.dart';
 import 'filter_state.dart';
 import 'state/global_state.dart';
+import 'data/mock_data_loader.dart';
 import 'ui/widgets/resizable_widget.dart';
 
 void main() async {
@@ -16,6 +17,12 @@ void main() async {
     await windowManager.setPreventClose(false);
     await windowManager.show();
   });
+
+  // Load mock data into global state before running the app.
+  final vaults = MockDataLoader.load();
+  GlobalState.conversationVaults.value = vaults;
+  GlobalState.conversationCount.value =
+      vaults.fold(0, (sum, v) => sum + v.conversations.length);
 
   runApp(const CodexVaultApp());
 }
@@ -158,7 +165,7 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                 ResizableWidget(
                   minWidth: 200,
                   maxWidth: 500,
-                  child: Container(
+                    child: Container(
                     margin: const EdgeInsets.all(8),
                     padding: const EdgeInsets.all(8),
                     color: Theme.of(context).colorScheme.surfaceVariant,
@@ -195,73 +202,48 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                             ],
                           );
                         }
-                        return ListView(
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.symmetric(
-                                  vertical: 4, horizontal: 8),
-                              child: Text(
-                                'Vaults',
-                                style:
-                                    Theme.of(context).textTheme.labelLarge,
-                              ),
-                            ),
-                            ListTile(
-                              dense: true,
-                              leading: const Icon(Icons.folder),
-                              title: const Text('Vault A'),
-                              trailing: const Icon(Icons.keyboard_arrow_down),
-                              onTap: () => GlobalState.selectedItemLabel.value =
-                                  'Selected: Vault A',
-                            ),
-                            Padding(
-                              padding: const EdgeInsets.only(left: 16),
-                              child: ListTile(
-                                dense: true,
-                                leading: const Icon(Icons.chat),
-                                title: const Text('Conversation A1'),
-                                trailing: const Icon(Icons.chevron_right),
-                                onTap: () => GlobalState
-                                    .selectedItemLabel
-                                    .value =
-                                    'Selected: Conversation A1',
-                              ),
-                            ),
-                            Padding(
-                              padding: const EdgeInsets.only(left: 16),
-                              child: ListTile(
-                                dense: true,
-                                leading: const Icon(Icons.chat),
-                                title: const Text('Conversation A2'),
-                                trailing: const Icon(Icons.chevron_right),
-                                onTap: () => GlobalState
-                                    .selectedItemLabel
-                                    .value =
-                                    'Selected: Conversation A2',
-                              ),
-                            ),
-                            ListTile(
-                              dense: true,
-                              leading: const Icon(Icons.folder),
-                              title: const Text('Vault B'),
-                              trailing: const Icon(Icons.keyboard_arrow_down),
-                              onTap: () => GlobalState.selectedItemLabel.value =
-                                  'Selected: Vault B',
-                            ),
-                            Padding(
-                              padding: const EdgeInsets.only(left: 16),
-                              child: ListTile(
-                                dense: true,
-                                leading: const Icon(Icons.chat),
-                                title: const Text('Conversation B1'),
-                                trailing: const Icon(Icons.chevron_right),
-                                onTap: () => GlobalState
-                                    .selectedItemLabel
-                                    .value =
-                                    'Selected: Conversation B1',
-                              ),
-                            ),
-                          ],
+                        return ValueListenableBuilder<List<Vault>>(
+                          valueListenable: GlobalState.conversationVaults,
+                          builder: (context, vaults, child) {
+                            return ListView(
+                              children: [
+                                Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                      vertical: 4, horizontal: 8),
+                                  child: Text(
+                                    'Vaults',
+                                    style: Theme.of(context).textTheme.labelLarge,
+                                  ),
+                                ),
+                                for (final vault in vaults) ...[
+                                  ListTile(
+                                    dense: true,
+                                    leading: const Icon(Icons.folder),
+                                    title: Text(vault.name),
+                                    trailing:
+                                        const Icon(Icons.keyboard_arrow_down),
+                                    onTap: () => GlobalState.selectedItemLabel
+                                        .value = 'Selected: ${vault.name}',
+                                  ),
+                                  for (final convo in vault.conversations)
+                                    Padding(
+                                      padding: const EdgeInsets.only(left: 16),
+                                      child: ListTile(
+                                        dense: true,
+                                        leading: const Icon(Icons.chat),
+                                        title: Text(convo.title),
+                                        trailing:
+                                            const Icon(Icons.chevron_right),
+                                        onTap: () => GlobalState
+                                            .selectedItemLabel
+                                            .value =
+                                            'Selected: ${convo.title}',
+                                      ),
+                                    ),
+                                ],
+                              ],
+                            );
+                          },
                         );
                       },
                     ),

--- a/lib/state/global_state.dart
+++ b/lib/state/global_state.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../data/mock_data_loader.dart';
 
 /// Supported LLM models for CodexVault.
 enum LLMModel { gpt35, gemini15 }
@@ -23,4 +24,8 @@ class GlobalState {
   /// Number of loaded conversations.
   static final ValueNotifier<int> conversationCount =
       ValueNotifier<int>(0);
+
+  /// Loaded vaults and their conversations.
+  static final ValueNotifier<List<Vault>> conversationVaults =
+      ValueNotifier<List<Vault>>([]);
 }


### PR DESCRIPTION
## Summary
- add `MockDataLoader` with `Vault` and `Conversation` classes
- store loaded vaults in `GlobalState.conversationVaults`
- load mock data in `main()` and update conversation count
- refactor navigation panel to render vaults and conversations dynamically
- update CODEX log

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68895696f69883219c84dad12e7bc148