### PR TITLE
Phase6 Task2 dynamic navigation

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -17,3 +17,4 @@
 [2507292220][d35ce9][FTR] Show selected item details in right panel
 [2507292313][3834de][FTR] Sync navigation panel with current view mode
 [2507292321][75aee2][FTR] Load mock data and render navigation dynamically
+[2507292327][1ba932][FTR] Render navigation with vault and conversation models

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'filter_state.dart';
 import 'state/global_state.dart';
 import 'data/mock_data_loader.dart';
 import 'ui/widgets/resizable_widget.dart';
+import 'package:intl/intl.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -212,35 +213,39 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                                       vertical: 4, horizontal: 8),
                                   child: Text(
                                     'Vaults',
-                                    style: Theme.of(context).textTheme.labelLarge,
+                                    style:
+                                        Theme.of(context).textTheme.labelLarge,
                                   ),
                                 ),
-                                for (final vault in vaults) ...[
-                                  ListTile(
-                                    dense: true,
+                                for (final vault in vaults)
+                                  ExpansionTile(
                                     leading: const Icon(Icons.folder),
                                     title: Text(vault.name),
-                                    trailing:
-                                        const Icon(Icons.keyboard_arrow_down),
-                                    onTap: () => GlobalState.selectedItemLabel
-                                        .value = 'Selected: ${vault.name}',
+                                    onExpansionChanged: (expanded) {
+                                      if (expanded) {
+                                        GlobalState.selectedItemLabel.value =
+                                            'Selected: ${vault.name}';
+                                      }
+                                    },
+                                    children: [
+                                      for (final convo in vault.conversations)
+                                        ListTile(
+                                          dense: true,
+                                          leading: const Icon(Icons.chat),
+                                          title: Text(convo.title),
+                                          subtitle: Text(DateFormat('yyyy-MM-dd HH:mm')
+                                              .format(convo.timestamp)),
+                                          trailing:
+                                              const Icon(Icons.chevron_right),
+                                          onTap: () {
+                                            GlobalState.selectedItemLabel.value =
+                                                'Selected: ${convo.title}';
+                                            GlobalState.selectedConversation
+                                                .value = convo;
+                                          },
+                                        ),
+                                    ],
                                   ),
-                                  for (final convo in vault.conversations)
-                                    Padding(
-                                      padding: const EdgeInsets.only(left: 16),
-                                      child: ListTile(
-                                        dense: true,
-                                        leading: const Icon(Icons.chat),
-                                        title: Text(convo.title),
-                                        trailing:
-                                            const Icon(Icons.chevron_right),
-                                        onTap: () => GlobalState
-                                            .selectedItemLabel
-                                            .value =
-                                            'Selected: ${convo.title}',
-                                      ),
-                                    ),
-                                ],
                               ],
                             );
                           },

--- a/lib/state/global_state.dart
+++ b/lib/state/global_state.dart
@@ -28,4 +28,8 @@ class GlobalState {
   /// Loaded vaults and their conversations.
   static final ValueNotifier<List<Vault>> conversationVaults =
       ValueNotifier<List<Vault>>([]);
+
+  /// Currently selected conversation from the navigation panel.
+  static final ValueNotifier<Conversation?> selectedConversation =
+      ValueNotifier<Conversation?>(null);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   window_manager: ^0.3.7
+  intl: ^0.18.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- render navigation with `ExpansionTile` widgets
- save tapped `Conversation` in `GlobalState.selectedConversation`
- add timestamp to conversation list using `intl`
- track selected `Conversation` for future detail panel updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68895875dcc48321ab14330db037a024