### PR TITLE
Implement navigation hover interactions

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -19,3 +19,4 @@
 [2507292321][75aee2][FTR] Load mock data and render navigation dynamically
 [2507292327][1ba932][FTR] Render navigation with vault and conversation models
 [2507292334][be4f57f][FTR] Populate detail panel with conversation preview
+[2507292342][2ce893][FTR][UI] Add hover and tap interactions for navigation

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -229,19 +229,57 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                                     },
                                     children: [
                                       for (final convo in vault.conversations)
-                                        ListTile(
-                                          dense: true,
-                                          leading: const Icon(Icons.chat),
-                                          title: Text(convo.title),
-                                          subtitle: Text(DateFormat('yyyy-MM-dd HH:mm')
-                                              .format(convo.timestamp)),
-                                          trailing:
-                                              const Icon(Icons.chevron_right),
-                                          onTap: () {
-                                            GlobalState.selectedItemLabel.value =
-                                                'Selected: ${convo.title}';
-                                            GlobalState.selectedConversation
-                                                .value = convo;
+                                        ValueListenableBuilder<String?>(
+                                          valueListenable:
+                                              GlobalState.hoveredConversationTitle,
+                                          builder: (context, hovered, child) {
+                                            final isHovered = hovered == convo.title;
+                                            return MouseRegion(
+                                              cursor: SystemMouseCursors.click,
+                                              onEnter: (_) {
+                                                GlobalState.hoveredConversationTitle
+                                                    .value = convo.title;
+                                                debugPrint('Hover: ${convo.title}');
+                                              },
+                                              onExit: (_) {
+                                                if (GlobalState
+                                                        .hoveredConversationTitle
+                                                        .value ==
+                                                    convo.title) {
+                                                  GlobalState.hoveredConversationTitle
+                                                      .value = null;
+                                                }
+                                              },
+                                              child: ListTile(
+                                                dense: true,
+                                                leading: const Icon(Icons.chat),
+                                                title: Text(
+                                                  convo.title,
+                                                  style: isHovered
+                                                      ? Theme.of(context)
+                                                          .textTheme
+                                                          .bodyMedium
+                                                          ?.copyWith(
+                                                              fontWeight:
+                                                                  FontWeight.bold)
+                                                      : null,
+                                                ),
+                                                subtitle: Text(DateFormat('yyyy-MM-dd HH:mm')
+                                                    .format(convo.timestamp)),
+                                                trailing:
+                                                    const Icon(Icons.chevron_right),
+                                                tileColor: isHovered
+                                                    ? Theme.of(context).hoverColor
+                                                    : null,
+                                                onTap: () {
+                                                  GlobalState.selectedItemLabel
+                                                          .value =
+                                                      'Selected: ${convo.title}';
+                                                  GlobalState.selectedConversation
+                                                      .value = convo;
+                                                },
+                                              ),
+                                            );
                                           },
                                         ),
                                     ],

--- a/lib/state/global_state.dart
+++ b/lib/state/global_state.dart
@@ -32,4 +32,8 @@ class GlobalState {
   /// Currently selected conversation from the navigation panel.
   static final ValueNotifier<Conversation?> selectedConversation =
       ValueNotifier<Conversation?>(null);
+
+  /// Title of the conversation currently hovered in the navigation panel.
+  static final ValueNotifier<String?> hoveredConversationTitle =
+      ValueNotifier<String?>(null);
 }


### PR DESCRIPTION
## Summary
- add ValueNotifier for hovered conversation
- implement hover feedback on conversation list tiles
- log hover actions in CODEX log

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68895c033c888321b1b75ad92d242a00