### PR TITLE
Implement responsive layout with LayoutBuilder

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -21,3 +21,4 @@
 [2507292334][be4f57f][FTR] Populate detail panel with conversation preview
 [2507292342][2ce893][FTR][UI] Add hover and tap interactions for navigation
 [2507292354][2fce80][FTR][UI] Apply Material 3 theming and spacing
+[2507300004][07df4a][FTR][UI] Add responsive layout scaling to main scaffold

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,13 +68,13 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
         child: const MenuBarWidget(),
       ),
       body: SafeArea(
-        child: Column(
-          children: [
-          Expanded(
-            child: Column(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final horizontalPadding = constraints.maxWidth < 600 ? 8.0 : 16.0;
+            return Column(
               children: [
                 Padding(
-            padding: const EdgeInsets.all(16),
+            padding: EdgeInsets.all(horizontalPadding),
             child: Material(
               elevation: 2,
               shape: RoundedRectangleBorder(
@@ -86,7 +86,7 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                   padding: const EdgeInsets.all(8),
                   child: Row(
                     children: [
-                      Flexible(
+                      Expanded(
                         flex: 1,
                         child: TextField(
                           controller: SearchFilterController.searchController,
@@ -105,7 +105,7 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                         ),
                       ),
                       const SizedBox(width: 12),
-                      Flexible(
+                      Expanded(
                         flex: 1,
                         child: TextField(
                           controller: SearchFilterController.filterController,
@@ -170,8 +170,8 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                   minWidth: 200,
                   maxWidth: 500,
                     child: Container(
-                    margin: const EdgeInsets.all(16),
-                    padding: const EdgeInsets.all(16),
+                    margin: EdgeInsets.all(horizontalPadding),
+                    padding: EdgeInsets.all(horizontalPadding),
                     color: Theme.of(context).colorScheme.surfaceVariant,
                     child: ValueListenableBuilder<ViewMode>(
                       valueListenable: GlobalState.currentViewMode,
@@ -297,8 +297,8 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
                 ),
                 Expanded(
                   child: Container(
-                    margin: const EdgeInsets.all(16),
-                    padding: const EdgeInsets.all(16),
+                    margin: EdgeInsets.all(horizontalPadding),
+                    padding: EdgeInsets.all(horizontalPadding),
                     color: Theme.of(context).colorScheme.surfaceVariant,
                     child: ValueListenableBuilder<Conversation?>(
                       valueListenable: GlobalState.selectedConversation,
@@ -388,7 +388,7 @@ class _ScaffoldWithMenuState extends State<ScaffoldWithMenu> {
               ),
             ),
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
+              padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
               child: Row(
                 children: [
                   ValueListenableBuilder<LLMModel>(

--- a/lib/ui/widgets/resizable_widget.dart
+++ b/lib/ui/widgets/resizable_widget.dart
@@ -37,21 +37,30 @@ class _ResizableWidgetState extends State<ResizableWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        SizedBox(width: _width, child: widget.child),
-        MouseRegion(
-          cursor: SystemMouseCursors.resizeLeftRight,
-          child: GestureDetector(
-            behavior: HitTestBehavior.translucent,
-            onHorizontalDragUpdate: (details) => _updateWidth(details.delta.dx),
-            child: Container(
-              width: 6,
-              color: Theme.of(context).dividerColor,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxAllowed =
+            constraints.maxWidth.clamp(widget.minWidth, widget.maxWidth);
+        final width = _width.clamp(widget.minWidth, maxAllowed);
+
+        return Row(
+          children: [
+            SizedBox(width: width, child: widget.child),
+            MouseRegion(
+              cursor: SystemMouseCursors.resizeLeftRight,
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onHorizontalDragUpdate: (details) =>
+                    _updateWidth(details.delta.dx),
+                child: Container(
+                  width: 6,
+                  color: Theme.of(context).dividerColor,
+                ),
+              ),
             ),
-          ),
-        ),
-      ],
+          ],
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- allow layout to adapt to window width using `LayoutBuilder`
- constrain navigation and detail containers responsively
- clamp resizable widget width to parent constraints
- update log

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688960a3bb148321adfa682dc63887c2