### PR TITLE
Fix model imports and definitions

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -29,3 +29,4 @@
 [2507302236][48a751][FTR][UI] Implement dark theme across widgets
 [2507310102][cf4df7][BUG][UI] Ensure maximized window and delayed runApp
 [2507310124][a303fb4][BUG][UI] Await window before runApp
+[2507310131][bc84a8][ERR] Define models and update imports

--- a/lib/data/mock_data_loader.dart
+++ b/lib/data/mock_data_loader.dart
@@ -1,19 +1,4 @@
-
-/// Represents a conversation item with a title and timestamp.
-class Conversation {
-  final String title;
-  final DateTime timestamp;
-
-  Conversation({required this.title, required this.timestamp});
-}
-
-/// Represents a vault containing a list of conversations.
-class Vault {
-  final String name;
-  final List<Conversation> conversations;
-
-  Vault({required this.name, required this.conversations});
-}
+import '../models/models.dart';
 
 /// Provides mock vault and conversation data for development.
 class MockDataLoader {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'filter_state.dart';
 import 'state/global_state.dart';
 import 'ui/widgets/resizable_navigation_panel.dart';
 import 'package:intl/intl.dart';
+import 'models/models.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,0 +1,11 @@
+class Vault {
+  final String name;
+  final List<Conversation> conversations;
+  Vault({required this.name, required this.conversations});
+}
+
+class Conversation {
+  final String title;
+  final DateTime timestamp;
+  Conversation({required this.title, required this.timestamp});
+}

--- a/lib/state/global_state.dart
+++ b/lib/state/global_state.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../data/mock_data_loader.dart';
+import '../models/models.dart';
 
 /// Supported LLM models for CodexVault.
 enum LLMModel { gpt35, gemini15 }


### PR DESCRIPTION
## Summary
- create `models/models.dart` defining `Vault` and `Conversation`
- import new models in `main.dart` and update state references
- use the new model classes in the mock data loader
- log update

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688ac6e0a3988321957744b61199d8d4