### PR TITLE
Verify TaskCreator references

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -30,3 +30,4 @@
 [2507310102][cf4df7][BUG][UI] Ensure maximized window and delayed runApp
 [2507310124][a303fb4][BUG][UI] Await window before runApp
 [2507310131][bc84a8][ERR] Define models and update imports
+[2507310149][164079][SNC] Verified absence of TaskCreator usages


### PR DESCRIPTION
## Summary
- confirm that there are no TaskCreator usages in the repository
- update log

## Testing
- `grep -R "TaskCreator" lib windows || true`

------
https://chatgpt.com/codex/tasks/task_b_688acb2e69808321a9e0ae864d3883b9