### PR TITLE
Implement raw JSON loading

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -30,3 +30,4 @@
 [2507310102][cf4df7][BUG][UI] Ensure maximized window and delayed runApp
 [2507310124][a303fb4][BUG][UI] Await window before runApp
 [2507310131][bc84a8][ERR] Define models and update imports
+[2507310204][3fc717][FTR][DATA] Add raw JSON loading system and in-memory model integration for ChatGPT exports

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'state/global_state.dart';
 import 'ui/widgets/resizable_navigation_panel.dart';
 import 'package:intl/intl.dart';
 import 'models/models.dart';
+import 'services/raw_memory_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -254,8 +255,43 @@ Widget build(BuildContext context) {
                         return ValueListenableBuilder<List<Vault>>(
                           valueListenable: GlobalState.conversationVaults,
                           builder: (context, vaults, child) {
+                            final rawConvos =
+                                RawMemoryService.instance.conversations;
+                            final showRaw =
+                                mode == ViewMode.all || mode == ViewMode.raw;
                             return ListView(
                               children: [
+                                if (showRaw && rawConvos.isNotEmpty) ...[
+                                  Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                        horizontal: 16, vertical: 8),
+                                    child: Text(
+                                      'Raw Conversations',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .labelMedium,
+                                    ),
+                                  ),
+                                  for (final raw in rawConvos)
+                                    ListTile(
+                                      dense: true,
+                                      leading:
+                                          const Icon(Icons.chat_bubble_outline),
+                                      title: Text(raw.title),
+                                      subtitle: Text(DateFormat('yyyy-MM-dd HH:mm')
+                                          .format(raw.timestamp)),
+                                      onTap: () {
+                                        final convo = Conversation(
+                                            title: raw.title,
+                                            timestamp: raw.timestamp);
+                                        GlobalState.selectedConversation.value =
+                                            convo;
+                                        GlobalState.selectedItemLabel.value =
+                                            'Selected: ${raw.title}';
+                                      },
+                                    ),
+                                  const Divider(),
+                                ],
                                 Padding(
                                   padding: const EdgeInsets.symmetric(
                                       horizontal: 16, vertical: 8),
@@ -536,12 +572,18 @@ class MenuBarWidget extends StatelessWidget {
           menuChildren: [
             MenuItemButton(
               leadingIcon: const Icon(Icons.insert_drive_file),
-              onPressed: () => MenuRouter.handle(MenuActions.openJson),
+              onPressed: () => MenuRouter.handle(context, MenuActions.openJson),
               child: const Text('Json'),
+            ),
+            MenuItemButton(
+              leadingIcon: const Icon(Icons.insert_drive_file),
+              onPressed: () =>
+                  MenuRouter.handle(context, MenuActions.openRawJson),
+              child: const Text('Raw JSON'),
             ),
                 MenuItemButton(
                   leadingIcon: const Icon(Icons.lock_open),
-                  onPressed: () => MenuRouter.handle(MenuActions.openVault),
+                  onPressed: () => MenuRouter.handle(context, MenuActions.openVault),
                   child: const Text('Vault'),
                 ),
               ],
@@ -552,12 +594,12 @@ class MenuBarWidget extends StatelessWidget {
               menuChildren: [
                 MenuItemButton(
                   onPressed: () =>
-                      MenuRouter.handle(MenuActions.exportPlaceholder1),
+                      MenuRouter.handle(context, MenuActions.exportPlaceholder1),
                   child: const Text('Placeholder1'),
                 ),
                 MenuItemButton(
                   onPressed: () =>
-                      MenuRouter.handle(MenuActions.exportPlaceholder2),
+                      MenuRouter.handle(context, MenuActions.exportPlaceholder2),
                   child: const Text('Placeholder2'),
                 ),
               ],
@@ -565,7 +607,7 @@ class MenuBarWidget extends StatelessWidget {
             ),
             MenuItemButton(
               leadingIcon: const Icon(Icons.exit_to_app),
-              onPressed: () => MenuRouter.handle(MenuActions.exitApp),
+              onPressed: () => MenuRouter.handle(context, MenuActions.exitApp),
               child: const Text('Exit'),
             ),
           ],
@@ -574,12 +616,12 @@ class MenuBarWidget extends StatelessWidget {
         SubmenuButton(
           menuChildren: [
             MenuItemButton(
-              onPressed: () => MenuRouter.handle(MenuActions.viewAll),
+              onPressed: () => MenuRouter.handle(context, MenuActions.viewAll),
               child: const Text('All'),
             ),
             MenuItemButton(
               leadingIcon: const Icon(Icons.view_list),
-              onPressed: () => MenuRouter.handle(MenuActions.viewContext),
+              onPressed: () => MenuRouter.handle(context, MenuActions.viewContext),
               child: const Text('Context'),
             ),
           ],
@@ -592,13 +634,13 @@ class MenuBarWidget extends StatelessWidget {
                 MenuItemButton(
                   leadingIcon: const Icon(Icons.smart_toy),
                   onPressed: () =>
-                      MenuRouter.handle(MenuActions.selectModelGpt),
+                  MenuRouter.handle(context, MenuActions.selectModelGpt),
                   child: const Text('GPT 3.5-turbo'),
                 ),
                 MenuItemButton(
                   leadingIcon: const Icon(Icons.memory),
                   onPressed: () =>
-                      MenuRouter.handle(MenuActions.selectModelGemini),
+                  MenuRouter.handle(context, MenuActions.selectModelGemini),
                   child: const Text('Gemini 1.5'),
                 ),
               ],

--- a/lib/menu_constants.dart
+++ b/lib/menu_constants.dart
@@ -1,5 +1,6 @@
 class MenuActions {
   static const String openJson = 'openJson';
+  static const String openRawJson = 'openRawJson';
   static const String openVault = 'openVault';
   static const String exportPlaceholder1 = 'exportPlaceholder1';
   static const String exportPlaceholder2 = 'exportPlaceholder2';

--- a/lib/menu_router.dart
+++ b/lib/menu_router.dart
@@ -1,13 +1,45 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+
 import 'menu_constants.dart';
 import 'menu_action_handler.dart';
+import 'services/raw_loader.dart';
+import 'services/raw_memory_service.dart';
+import 'state/global_state.dart';
+import 'package:flutter/material.dart';
 
 /// Routes menu action strings to their corresponding handlers in [MenuActionHandler].
 class MenuRouter {
   /// Dispatches a menu [action] to the proper handler.
-  static void handle(String action) {
+  static Future<void> handle(BuildContext context, String action) async {
     switch (action) {
       case MenuActions.openJson:
         MenuActionHandler.onOpenJson();
+        break;
+      case MenuActions.openRawJson:
+        final result = await FilePicker.platform.pickFiles(
+          type: FileType.custom,
+          allowedExtensions: ['json'],
+        );
+        if (result != null && result.files.single.path != null) {
+          try {
+            await RawLoader.loadRawJson(File(result.files.single.path!));
+            GlobalState.conversationCount.value =
+                RawMemoryService.instance.conversations.length;
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                  'Loaded \${RawMemoryService.instance.conversations.length} conversations',
+                ),
+              ),
+            );
+          } catch (e) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Failed to load JSON: \$e')),
+            );
+          }
+        }
         break;
       case MenuActions.openVault:
         MenuActionHandler.onOpenVault();

--- a/lib/models/raw/raw_conversation.dart
+++ b/lib/models/raw/raw_conversation.dart
@@ -1,0 +1,13 @@
+class RawConversation {
+  final String id;
+  final String title;
+  final DateTime timestamp;
+  final List<RawExchange> exchanges;
+
+  RawConversation({
+    required this.id,
+    required this.title,
+    required this.timestamp,
+    required this.exchanges,
+  });
+}

--- a/lib/models/raw/raw_exchange.dart
+++ b/lib/models/raw/raw_exchange.dart
@@ -1,0 +1,13 @@
+class RawExchange {
+  final String id;
+  final String prompt;
+  final String response;
+  final DateTime timestamp;
+
+  RawExchange({
+    required this.id,
+    required this.prompt,
+    required this.response,
+    required this.timestamp,
+  });
+}

--- a/lib/services/raw_loader.dart
+++ b/lib/services/raw_loader.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../models/raw/raw_conversation.dart';
+import '../models/raw/raw_exchange.dart';
+import 'raw_memory_service.dart';
+
+class RawLoader {
+  /// Loads a ChatGPT raw JSON export [file] into memory.
+  static Future<void> loadRawJson(File file) async {
+    final text = await file.readAsString();
+    final dynamic data = jsonDecode(text);
+    if (data is! Map || !data.containsKey('conversations')) {
+      throw FormatException('Invalid ChatGPT export structure');
+    }
+    final convList = data['conversations'];
+    if (convList is! List) {
+      throw FormatException('Invalid conversations list');
+    }
+    final parsed = <RawConversation>[];
+    for (final conv in convList) {
+      if (conv is! Map) continue;
+      final id = conv['id']?.toString() ?? '';
+      final title = conv['title']?.toString() ?? 'Untitled';
+      final tsNum = conv['create_time'];
+      final timestamp = tsNum is num
+          ? DateTime.fromMillisecondsSinceEpoch((tsNum * 1000).toInt())
+          : DateTime.now();
+      final mapping = conv['mapping'];
+      if (mapping is! Map) continue;
+      final messages = mapping.values
+          .whereType<Map>()
+          .where((m) => m['message'] != null)
+          .toList();
+      messages.sort((a, b) {
+        final ta = a['message']['create_time'] ?? 0;
+        final tb = b['message']['create_time'] ?? 0;
+        if (ta is num && tb is num) return ta.compareTo(tb);
+        return 0;
+      });
+
+      final exchanges = <RawExchange>[];
+      String? prompt;
+      String? idHolder;
+      DateTime? tsHolder;
+      for (final msg in messages) {
+        final message = msg['message'];
+        final role = message['author']?['role'];
+        final parts = message['content']?['parts'];
+        final text =
+            (parts is List && parts.isNotEmpty) ? parts.first.toString() : '';
+        final timeNum = message['create_time'];
+        final msgTime = timeNum is num
+            ? DateTime.fromMillisecondsSinceEpoch((timeNum * 1000).toInt())
+            : DateTime.now();
+        if (role == 'user') {
+          prompt = text;
+          idHolder = message['id']?.toString() ?? msg['id']?.toString();
+          tsHolder = msgTime;
+        } else if (role == 'assistant' && prompt != null) {
+          exchanges.add(RawExchange(
+            id: idHolder ?? message['id']?.toString() ?? '',
+            prompt: prompt,
+            response: text,
+            timestamp: tsHolder ?? msgTime,
+          ));
+          prompt = null;
+          idHolder = null;
+          tsHolder = null;
+        }
+      }
+      parsed.add(RawConversation(
+          id: id, title: title, timestamp: timestamp, exchanges: exchanges));
+    }
+
+    final memory = RawMemoryService.instance;
+    memory.clear();
+    memory.addAll(parsed);
+  }
+}

--- a/lib/services/raw_memory_service.dart
+++ b/lib/services/raw_memory_service.dart
@@ -1,0 +1,19 @@
+import '../models/raw/raw_conversation.dart';
+
+class RawMemoryService {
+  RawMemoryService._();
+
+  static final RawMemoryService instance = RawMemoryService._();
+
+  final List<RawConversation> _conversations = [];
+
+  List<RawConversation> get conversations => List.unmodifiable(_conversations);
+
+  void clear() {
+    _conversations.clear();
+  }
+
+  void addAll(List<RawConversation> convos) {
+    _conversations.addAll(convos);
+  }
+}

--- a/lib/state/global_state.dart
+++ b/lib/state/global_state.dart
@@ -5,7 +5,7 @@ import '../models/models.dart';
 enum LLMModel { gpt35, gemini15 }
 
 /// Available view modes for the application.
-enum ViewMode { all, context, vault, conversation, exchange }
+enum ViewMode { all, raw, context, vault, conversation, exchange }
 
 /// Provides global state notifiers for the UI.
 class GlobalState {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   window_manager: ^0.3.7
   intl: ^0.18.1
+  file_picker: ^6.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add models for raw conversations and exchanges
- implement RawMemoryService and RawLoader
- integrate file picker menu action to import raw ChatGPT exports
- display raw conversations in navigation panel when view mode is all or raw
- update view modes and menu constants
- log raw JSON feature

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688ace02e4f483218b55f040ca6bb50f